### PR TITLE
Fix missing import for createInterface

### DIFF
--- a/codex-cli/src/utils/responses.ts
+++ b/codex-cli/src/utils/responses.ts
@@ -8,6 +8,7 @@ import { spawn } from "node:child_process";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
+import { createInterface } from "node:readline";
 
 // Define interfaces based on OpenAI API documentation
 type ResponseCreateInput = ResponseCreateParams;


### PR DESCRIPTION
## Summary
- fix runtime error in responses utility by importing `createInterface`

## Testing
- `pnpm --filter @openai/codex run lint` *(fails: 17 errors)*
- `pnpm --filter @openai/codex run typecheck` *(fails to typecheck)*
- `pnpm --filter @openai/codex run test` *(fails: 20 failed, 53 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68460046605c8327a8ab335aa5d62384