### PR TITLE
Fix approximate token count when text/refusal missing

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -22,7 +22,10 @@ import {
 } from "../config.js";
 import { log } from "../logger/log.js";
 import { parseToolCallArguments } from "../parsers.js";
-import { responsesCreateViaChatCompletions } from "../responses.js";
+import {
+  responsesCreateViaChatCompletions,
+  callCustomLLM,
+} from "../responses.js";
 import {
   ORIGIN,
   getSessionId,
@@ -32,12 +35,8 @@ import {
 import { applyPatchToolInstructions } from "./apply-patch.js";
 import { handleExecCommand } from "./handle-exec-command.js";
 import { HttpsProxyAgent } from "https-proxy-agent";
-
 import OpenAI, { APIConnectionTimeoutError, AzureOpenAI } from "openai";
 import { randomUUID } from "crypto";
-
-import { callCustomLLM } from "/home2/srallaba/projects/project_codex/repos/codex/codex-cli/src/utils/responses"
-
 // Wait time before retrying after rate limit errors (ms).
 const RATE_LIMIT_RETRY_WAIT_MS = parseInt(
   process.env["OPENAI_RATE_LIMIT_RETRY_WAIT_MS"] || "500",

--- a/codex-cli/src/utils/approximate-tokens-used.ts
+++ b/codex-cli/src/utils/approximate-tokens-used.ts
@@ -25,9 +25,9 @@ export function approximateTokensUsed(items: Array<ResponseItem>): number {
 
         for (const c of item.content) {
           if (c.type === "input_text" || c.type === "output_text") {
-            charCount += c.text.length;
+            charCount += c.text?.length ?? 0;
           } else if (c.type === "refusal") {
-            charCount += c.refusal.length;
+            charCount += c.refusal?.length ?? 0;
           } else if (c.type === "input_file") {
             charCount += c.filename?.length ?? 0;
           }

--- a/codex-cli/tests/approximate-tokens-used.test.ts
+++ b/codex-cli/tests/approximate-tokens-used.test.ts
@@ -29,4 +29,22 @@ describe("approximateTokensUsed", () => {
     ];
     expect(approximateTokensUsed(items)).toBe(2); // ceil(5/4)
   });
+
+  it("handles missing text or refusal fields", () => {
+    const items: Array<ResponseItem> = [
+      {
+        id: "1",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [
+          { type: "output_text", text: undefined as unknown as string },
+          { type: "refusal", refusal: undefined as unknown as string },
+        ],
+      } as ResponseItem,
+    ];
+
+    expect(() => approximateTokensUsed(items)).not.toThrow();
+    expect(approximateTokensUsed(items)).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- handle undefined text/refusal in `approximateTokensUsed`
- test for missing text or refusal

## Testing
- `pnpm install`
- `pnpm test` *(fails: 25 failed, 57 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6846094427708327b25cd7596767eca5