### PR TITLE
Fix call_gpt and add verification script

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install python deps if needed and compile
+pip install -q httpx openai requests
+python3 -m py_compile scripts/call_gpt.py
+
+# prepare sanitized input
+TMP_INPUT=$(mktemp)
+tail -n +2 codex-cli/log.in > "$TMP_INPUT"
+
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+  python3 scripts/call_gpt.py < "$TMP_INPUT"
+else
+  echo "OPENAI_API_KEY not set; skipping call_gpt.py run"
+fi
+
+if command -v pnpm >/dev/null 2>&1; then
+  if [ -d codex-cli/node_modules ]; then
+    (cd codex-cli && pnpm test)
+  else
+    echo "node_modules missing; skipping codex-cli tests"
+  fi
+else
+  echo "pnpm not found; skipping codex-cli tests"
+fi
+
+rm -f "$TMP_INPUT"


### PR DESCRIPTION
## Summary
- handle missing API key in `call_gpt.py`
- use synchronous OpenAI calls in `call_gpt.py`
- add `scripts/verify.sh` to compile `call_gpt.py`, run it with sample input, and execute codex-cli tests when dependencies exist

## Testing
- `python3 -m py_compile scripts/call_gpt.py`
- `bash scripts/verify.sh` *(fails to run codex-cli tests due to missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_6847417e2eb48327ae5d3e27e5db8574