### PR TITLE
Fix Windows command spawn

### DIFF
--- a/codex-cli/src/shims-external.d.ts
+++ b/codex-cli/src/shims-external.d.ts
@@ -22,3 +22,13 @@ declare module "fast-npm-meta" {
 declare module "semver" {
   export function gt(v1: string, v2: string): boolean;
 }
+
+declare module "cross-spawn" {
+  import type { ChildProcess, SpawnOptions } from "child_process";
+  function crossSpawn(
+    command: string,
+    args?: ReadonlyArray<string>,
+    options?: SpawnOptions,
+  ): ChildProcess;
+  export = crossSpawn;
+}

--- a/codex-cli/src/utils/agent/platform-commands.ts
+++ b/codex-cli/src/utils/agent/platform-commands.ts
@@ -19,6 +19,21 @@ const COMMAND_MAP: Record<string, string> = {
 };
 
 /**
+ * List of commands that are built into `cmd.exe` on Windows. These do not
+ * correspond to standalone executables, meaning they must be executed through
+ * the shell.
+ */
+const CMD_BUILTINS = new Set([
+  "dir",
+  "copy",
+  "move",
+  "del",
+  "type",
+  "echo.>",
+  "md",
+]);
+
+/**
  * Map of common Unix command options to their Windows equivalents
  */
 const OPTION_MAP: Record<string, Record<string, string>> = {
@@ -77,6 +92,11 @@ export function adaptCommandForPlatform(command: Array<string>): Array<string> {
   }
 
   log(`Adapted command: ${adaptedCommand.join(" ")}`);
+
+  if (CMD_BUILTINS.has(adaptedCommand[0])) {
+    // Wrap built-in commands so that `spawn` executes them via cmd.exe
+    return ["cmd.exe", "/c", ...adaptedCommand];
+  }
 
   return adaptedCommand;
 }

--- a/codex-cli/src/utils/agent/sandbox/raw-exec.ts
+++ b/codex-cli/src/utils/agent/sandbox/raw-exec.ts
@@ -11,7 +11,7 @@ import type {
 import { log } from "../../logger/log.js";
 import { adaptCommandForPlatform } from "../platform-commands.js";
 import { createTruncatingCollector } from "./create-truncating-collector";
-import { spawn } from "child_process";
+import crossSpawn from "cross-spawn";
 import * as os from "os";
 
 /**
@@ -84,7 +84,11 @@ export function exec(
     detached: true,
   };
 
-  const child: ChildProcess = spawn(prog, adaptedCommand.slice(1), fullOptions);
+  const child: ChildProcess = crossSpawn(
+    prog,
+    adaptedCommand.slice(1),
+    fullOptions,
+  );
   // If an AbortSignal is provided, ensure the spawned process is terminated
   // when the signal is triggered so that cancellations propagate down to any
   // long‑running child processes. We default to SIGTERM to give the process a


### PR DESCRIPTION
## Summary
- wrap Windows builtin commands in `cmd.exe` so spawn can find them
- use cross-spawn for raw exec on all platforms

## Testing
- `pnpm test` *(fails: vitest tests)*
- `pnpm run lint` *(fails: ESLint couldn't find config)*
- `pnpm run typecheck` *(fails: missing @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_684767786b808327840b186423aa4c2e