### PR TITLE
Fix lint and type errors

### DIFF
--- a/codex-cli/src/utils/responses.ts
+++ b/codex-cli/src/utils/responses.ts
@@ -1,14 +1,15 @@
-import path from "path";
-import { fileURLToPath } from "url";
-import { spawn } from "child_process";
-import { createInterface } from "readline";
-import type { Readable } from "stream";
 import type { OpenAI } from "openai";
 import type {
   ResponseCreateParams,
   Response,
 } from "openai/resources/responses/responses";
+import type { Readable } from "stream";
+
 import { log } from "./logger/log.js";
+import { spawn } from "child_process";
+import path from "path";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
 
 // Define interfaces based on OpenAI API documentation
 type ResponseCreateInput = ResponseCreateParams;
@@ -267,7 +268,7 @@ function convertTools(
     }));
 }
 
-const createCompletion = (openai: OpenAI, input: ResponseCreateInput) => {
+const createCompletion = (input: ResponseCreateInput) => {
   const fullMessages = getFullMessages(input);
   const chatTools = convertTools(input.tools);
   const webSearchOptions = input.tools?.some(
@@ -296,18 +297,15 @@ const createCompletion = (openai: OpenAI, input: ResponseCreateInput) => {
 
 // Main function with overloading
 async function responsesCreateViaChatCompletions(
-  openai: OpenAI,
   input: ResponseCreateInput & { stream: true },
 ): Promise<AsyncGenerator<ResponseEvent>>;
 async function responsesCreateViaChatCompletions(
-  openai: OpenAI,
   input: ResponseCreateInput & { stream?: false },
 ): Promise<ResponseOutput>;
 async function responsesCreateViaChatCompletions(
-  openai: OpenAI,
   input: ResponseCreateInput,
 ): Promise<ResponseOutput | AsyncGenerator<ResponseEvent>> {
-  const completion = await createCompletion(openai, input);
+  const completion = await createCompletion(input);
   if (input.stream) {
     return streamResponses(
       input,
@@ -716,7 +714,7 @@ async function* streamResponses(
 }
 
 
-function callCustomLLM(messages: any): AsyncIterable<any> {
+function callCustomLLM(messages: unknown): AsyncIterable<unknown> {
   const scriptPath = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "../../scripts/call_gpt.py",
@@ -744,7 +742,9 @@ function callCustomLLM(messages: any): AsyncIterable<any> {
 
   }
 
-  return { [Symbol.asyncIterator]: generator } as AsyncIterable<any>;
+  return {
+    [Symbol.asyncIterator]: generator,
+  } as AsyncIterable<unknown>;
 }
 
 export {

--- a/codex-cli/tests/call-custom-llm.test.ts
+++ b/codex-cli/tests/call-custom-llm.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { callCustomLLM } from "../src/utils/responses";
 import { Readable } from "node:stream";
 import { spawn } from "node:child_process";
@@ -14,7 +14,7 @@ describe("callCustomLLM", () => {
 
   it("yields parsed JSON lines from stdout", async () => {
     const fakeStdout = new Readable({ read() {} });
-    (spawn as unknown as vi.Mock).mockReturnValue({
+  (spawn as unknown as Mock).mockReturnValue({
       stdout: fakeStdout,
       stdin: { write: vi.fn(), end: vi.fn() },
     });


### PR DESCRIPTION
## Summary
- sort imports in `responses.ts`
- type improvements in `call-custom-llm.test.ts`
- simplify `callCustomLLM` typing
- remove unused OpenAI client

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `CODEX_SANDBOX_NETWORK_DISABLED=1 pnpm test` *(fails: TypeError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68476c8fc21c8327b8842121c717a88e