### PR TITLE
Enable shell execution for sandbox commands

### DIFF
--- a/codex-cli/src/utils/agent/sandbox/raw-exec.ts
+++ b/codex-cli/src/utils/agent/sandbox/raw-exec.ts
@@ -74,6 +74,9 @@ export function exec(
     StdioPipe
   > = {
     ...options,
+    // Ensure the command runs through the shell so built-ins like `ls`
+    // resolve correctly even when not available as standalone executables.
+    shell: true,
     // Inherit any caller‑supplied stdio flags but force stdin to "ignore" so
     // the child never attempts to read from us (see lengthy comment above).
     stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary
- run spawned commands through the shell so utilities like `ls` resolve on all platforms

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined ...)*

------
https://chatgpt.com/codex/tasks/task_e_6847707f954883278dd0796c427719b2