### PR TITLE
Fix undefined input in response processing

### DIFF
--- a/codex-cli/src/utils/responses.ts
+++ b/codex-cli/src/utils/responses.ts
@@ -187,8 +187,12 @@ function generateId(prefix: string = "msg"): string {
 type ResponseInputItem = ResponseCreateInput["input"][number];
 
 function convertInputItemToMessage(
-  item: string | ResponseInputItem,
+  item: string | ResponseInputItem | undefined | null,
 ): OpenAI.Chat.Completions.ChatCompletionMessageParam {
+  if (item == null) {
+    throw new Error("Invalid input item: received null or undefined");
+  }
+
   // Handle string inputs as content for a user message
   if (typeof item === "string") {
     return { role: "user", content: item };
@@ -238,8 +242,10 @@ function getFullMessages(
 
   // Handle both string and ResponseInputItem in input.input
   const newInputMessages = Array.isArray(input.input)
-    ? input.input.map(convertInputItemToMessage)
-    : [convertInputItemToMessage(input.input)];
+    ? input.input.filter((itm) => itm != null).map(convertInputItemToMessage)
+    : input.input != null
+      ? [convertInputItemToMessage(input.input)]
+      : [];
 
   const messages = [...baseHistory, ...newInputMessages];
   if (

--- a/codex-cli_backup/src/utils/responses.ts
+++ b/codex-cli_backup/src/utils/responses.ts
@@ -186,8 +186,12 @@ function generateId(prefix: string = "msg"): string {
 type ResponseInputItem = ResponseCreateInput["input"][number];
 
 function convertInputItemToMessage(
-  item: string | ResponseInputItem,
+  item: string | ResponseInputItem | undefined | null,
 ): OpenAI.Chat.Completions.ChatCompletionMessageParam {
+  if (item == null) {
+    throw new Error("Invalid input item: received null or undefined");
+  }
+
   // Handle string inputs as content for a user message
   if (typeof item === "string") {
     return { role: "user", content: item };
@@ -237,8 +241,10 @@ function getFullMessages(
 
   // Handle both string and ResponseInputItem in input.input
   const newInputMessages = Array.isArray(input.input)
-    ? input.input.map(convertInputItemToMessage)
-    : [convertInputItemToMessage(input.input)];
+    ? input.input.filter((itm) => itm != null).map(convertInputItemToMessage)
+    : input.input != null
+      ? [convertInputItemToMessage(input.input)]
+      : [];
 
   const messages = [...baseHistory, ...newInputMessages];
   if (


### PR DESCRIPTION
## Summary
- handle `null`/`undefined` items when converting input to messages
- ignore empty entries when building message lists

## Testing
- `pnpm test` *(fails: Cannot find package 'dotenv' imported from '/workspace/codex/codex-cli/src/utils/config.ts')*

------
https://chatgpt.com/codex/tasks/task_e_6847a792816483278e65484859dc2cb6